### PR TITLE
Fix viewport link

### DIFF
--- a/src/templates/index.pug
+++ b/src/templates/index.pug
@@ -439,4 +439,4 @@ block content
 	section.ui-section
 		h1 Editors
 		h2
-			a(href="/viewport.html") Viewport
+			a(href="/viewport/") Viewport


### PR DESCRIPTION
The link was broken since the viewport was moved to its own folder.